### PR TITLE
Added ability for custom fonts

### DIFF
--- a/src/A6digital/Image/DefaultProfileImage.php
+++ b/src/A6digital/Image/DefaultProfileImage.php
@@ -15,7 +15,7 @@ class DefaultProfileImage
 	 * @return ImageManagerStatic
 	 * @throws Exception
 	 */
-	public static function create ($name = '', $size = 512, $background_color = '#666', $text_color = '#FFF')
+	public static function create ($name = '', $size = 512, $background_color = '#666', $text_color = '#FFF', $font_file = '../../../font/OpenSans-Semibold.ttf')
 	{
 	
 		if (strlen($name) <= 0) {
@@ -26,6 +26,14 @@ class DefaultProfileImage
 			throw new Exception('Input must be greater than zero.');
 		}
 
+        if ($font_file === '../../../font/OpenSans-Semibold.ttf') {
+            $font_file = __DIR__."/".$font_file;
+        }
+
+        if (!file_exists($font_file)) {
+            throw new Exception("Font file not found");
+        }
+
 		$str = "";
 		$name_ascii = strtoupper(Str::ascii($name));
 
@@ -33,8 +41,8 @@ class DefaultProfileImage
 		if(count($words) >= 2) $str = $words[0][0].$words[1][0];
 		else $str = substr($name_ascii, 0, 2);
 
-		$img = ImageManagerStatic::canvas($size, $size, $background_color)->text($str, $size / 2, $size / 2, function($font) use($size, $text_color) {
-			$font->file((__DIR__.'/../../../font/OpenSans-Semibold.ttf'));
+		$img = ImageManagerStatic::canvas($size, $size, $background_color)->text($str, $size / 2, $size / 2, function($font) use($size, $text_color, $font_file) {
+			$font->file($font_file);
 			$font->size($size / 2);
 			$font->color($text_color);
 			$font->align('center');


### PR DESCRIPTION
I removed the hard-coded font file path and extracted it out into an argument that can be fed to the create static function.  I also added the checks for if it's equal to the default (and if it's not, it'll assume we're passing it a absolute path).

Thanks for the great work on this, using it in my project right now!

Example of my use:

```
        $defaultProfilePhoto = \DefaultProfileImage::create("@ " . strtoupper($data['name']), 256, "#212121", "#FFF", '/var/www/public/fonts/RobotoDraftRegular.woff');
```

Default font
![screen shot 2015-05-01 at 5 24 54 am](https://cloud.githubusercontent.com/assets/5675626/7428702/2274811c-efc3-11e4-9291-b229639ba54c.png)

Roboto font
![screen shot 2015-05-01 at 5 29 50 am](https://cloud.githubusercontent.com/assets/5675626/7428706/2c8fe2cc-efc3-11e4-9ac2-9564ae0fbf16.png)
